### PR TITLE
Update urvanov_syntax_highlighter_style.css

### DIFF
--- a/css/src/urvanov_syntax_highlighter_style.css
+++ b/css/src/urvanov_syntax_highlighter_style.css
@@ -84,7 +84,7 @@ coloring etc.
 .urvanov-syntax-highlighter-syntax .crayon-table tr {
     padding: 0 !important;
     border: none !important;
-    background: none;
+    background: none !important;
     vertical-align: top !important;
     margin: 0 !important;
 }


### PR DESCRIPTION
Hello,

I'm using the KnowAll theme and plugin from HeroThemes (https://herothemes.com/themes/knowall-wordpress-knowledge-base/).

In order to get anything other than a white background in your code highlighter, I needed to add the `!important` indicator to one of the background tags. Hopefully this makes sense and works for you.

Let me know if you have any questions.

Thanks!

![Dark-theme-before](https://user-images.githubusercontent.com/2582936/168309437-fd7624e8-6acc-479c-9d35-72abd2450b85.png)
![Dark-theme-after](https://user-images.githubusercontent.com/2582936/168309468-6b4bbcca-3535-45fd-9000-d5093822b943.png)
