### PR TITLE
Function _load_textdomain_just_in_time was called incorrectly.

### DIFF
--- a/class-urvanov-syntax-highlighter-plugin.php
+++ b/class-urvanov-syntax-highlighter-plugin.php
@@ -1345,7 +1345,9 @@ if (defined('ABSPATH')) {
     if (!is_admin()) {
         // Filters and Actions
 
-        add_filter('init', 'Urvanov_Syntax_Highlighter_Plugin::init');
+	// XXX add_filter('init', 'Urvanov_Syntax_Highlighter_Plugin::init');
+	// XXX moved load_textdomain to after_setup_theme, so that it loads after init as it is required in WP 6.7
+	add_filter('after_setup_theme', 'Urvanov_Syntax_Highlighter_Plugin::init');
 
         Urvanov_Syntax_Highlighter_Settings_WP::load_settings(TRUE);
         if (Urvanov_Syntax_Highlighter_Global_Settings::val(Urvanov_Syntax_Highlighter_Settings::MAIN_QUERY)) {

--- a/class-urvanov-syntax-highlighter-settings.php
+++ b/class-urvanov-syntax-highlighter-settings.php
@@ -155,7 +155,9 @@ class Urvanov_Syntax_Highlighter_Settings {
     private function init() {
         global $URVANOV_SYNTAX_HIGHLIGHTER_VERSION;
 
-        Urvanov_Syntax_Highlighter_Global::load_plugin_textdomain();
+	// XXX Urvanov_Syntax_Highlighter_Global::load_plugin_textdomain();
+	// XXX moved load_textdomain to after_setup_theme, so that it loads after init as it is required in WP 6.7
+	add_filter('after_setup_theme', 'Urvanov_Syntax_Highlighter_Global::load_plugin_textdomain');
 
         self::$cache_array = array(Urvanov_Syntax_Highlighter_Global::urvanov__('Hourly') => 3600, Urvanov_Syntax_Highlighter_Global::urvanov__('Daily') => 86400,
             Urvanov_Syntax_Highlighter_Global::urvanov__('Weekly') => 604800, Urvanov_Syntax_Highlighter_Global::urvanov__('Monthly') => 18144000,


### PR DESCRIPTION
Hi,

the latest WP requires to load the textdomain after 'init'. I would suggest those changes.

Greetings,

Andreas